### PR TITLE
Adding JetBrains Rider (.NET IDE) specific files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ src/scaffolding.config
 
 # Approval tests temp file
 *.received.*
+
+# JetBrains Rider
+.idea/
+*.sln.iml


### PR DESCRIPTION
[Rider](https://blog.jetbrains.com/dotnet/2016/01/13/project-rider-a-csharp-ide/) is an upcoming .NET IDE from JetBrains. As all other IntelliJ-based IDEs, it creates workspace files that should be ignored. This PR adds files specific to Rider to .gitignore.