### PR TITLE
Remove merge=union from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -64,11 +64,6 @@
 *.bat text eol=crlf
 
 # Custom for Visual Studio
-*.csproj merge=union
-*.vbproj merge=union
-*.fsproj merge=union
-*.dbproj merge=union 
-*.sln text eol=crlf merge=union
 *.suo 	-text -diff
 *.snk 	-text -diff
 *.cub 	-text -diff


### PR DESCRIPTION
Setting merge=union for project files just ends up causing worse problems. If a merge conflict in a project file occurs, you just end up with both versions in the file instead, which is never what you want.

See http://haacked.com/archive/2014/04/16/csproj-merge-conflicts/ for more info.

CC: @timbussmann 