### PR TITLE
update nuget.config

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -6,13 +6,10 @@
     <add key="automatic" value="True" />
   </packageRestore>
   <packageSources>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="particular myget.org" value="https://www.myget.org/F/particular/" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="particular myget.org" value="https://www.myget.org/F/particular/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
-  <config>
-    <add key="DependencyVersion" value="HighestMinor" />
-  </config>
   <activePackageSource>
     <clear />
     <add key="All" value="(Aggregate source)" />

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,10 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <packageRestore>
-    <clear />
-    <add key="enabled" value="True" />
-    <add key="automatic" value="True" />
-  </packageRestore>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="particular myget.org" value="https://www.myget.org/F/particular/api/v3/index.json" />

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -9,9 +9,4 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="particular myget.org" value="https://www.myget.org/F/particular/api/v3/index.json" />
   </packageSources>
-  <disabledPackageSources />
-  <activePackageSource>
-    <clear />
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
 </configuration>


### PR DESCRIPTION
I think there is no reason for not updating to the latest API versions.

as far as I understood, the `activePackageSource` setting is limitted to v2 as well (https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file#activepackagesource) so that can probably be removed too?

thoughts @bording ?