### PR TITLE
Enable deterministic CI builds

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,4 +7,18 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(CI)' != '' Or '$(TEAMCITY_VERSION)' != ''">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SourceRoot Include="$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)..\))" />
+  </ItemGroup>
+
+  <!-- Workaround for https://github.com/NuGet/Home/issues/9431 -->
+  <ItemGroup>
+    <SourceRoot Include="$(NuGetPackageRoot)" Condition="'$(NuGetPackageRoot)' != ''" />
+  </ItemGroup>
+  <!-- End Workaround -->
+
 </Project>


### PR DESCRIPTION
These changes will allow us to get deterministic builds when we build on CI.

The `SourceRoot` items are to ensure that the source path mapping works properly. This features anonymizes the paths names for source files.

AFAIK this should be safe to enable for all repos that are already syncing this file.