### PR TITLE
Adjust standards to no longer force C# 7.3 and instead rely on tooling defaults

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,6 @@
   <Import Project="Custom.Build.props" Condition="Exists('Custom.Build.props')" />
 
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
Tooling, eg. visual studio, MSBuild, already selects the appropriate language version depending on the target frameworks used so there is no need for us to force it.