### PR TITLE
Do not enforce object initializers

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -53,7 +53,6 @@ dotnet_style_parentheses_in_other_operators = never_if_unnecessary:error
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:error
 
 # Expression-level preferences
-dotnet_diagnostic.IDE0017.severity = error
 dotnet_style_object_initializer = true:error
 
 dotnet_diagnostic.IDE0028.severity = error


### PR DESCRIPTION
It's very annoying that the code now doesn't even compile when the IDE wants me to use object initializers, even though I intentionally do not want to use an object initializer in some places. I see very little reason to enforce usage of object initializers as errors (fine with making it some kind of warning of hint or whatever).

What's the process to suggest/change code styles now @bording @SeanFeldman ?