### PR TITLE
Use pull_request_target

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,6 @@
 name: Dependabot Auto Merge
 on:
-  pull_request:
+  pull_request_target:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,6 +3,7 @@ on:
   pull_request_target:
 jobs:
   auto-merge:
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Change the dependabot auto-merge action to rely on the `pull_request_target` event to overcome [new security rules](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/) for dependabot PRs

More information in https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60