### PR TITLE
add CA1068 — CancellationToken parameters must come last

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -20,6 +20,7 @@ insert_final_newline = false
 
 #### Code quality analysis
 
+dotnet_diagnostic.CA1068.severity = error
 dotnet_diagnostic.CA2007.severity = error
 dotnet_diagnostic.CA2016.severity = error
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1068

I tested this change locally by editing a `.editorconfig` and moving a token param, and the diagnostic was shown.