### PR TITLE
Change pattern matching to suggestion

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -151,11 +151,11 @@ dotnet_diagnostic.IDE0020.severity = error
 dotnet_diagnostic.IDE0038.severity = error
 csharp_style_pattern_matching_over_is_with_cast_check = true:error
 
-dotnet_diagnostic.IDE0083.severity = error
-csharp_style_prefer_not_pattern = true:error
+dotnet_diagnostic.IDE0083.severity = suggestion
+csharp_style_prefer_not_pattern = true:suggestion
 
-dotnet_diagnostic.IDE0078.severity = error
-csharp_style_prefer_pattern_matching = true:error
+dotnet_diagnostic.IDE0078.severity = suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
 
 dotnet_diagnostic.IDE0066.severity = error
 csharp_style_prefer_switch_expression = true:error


### PR DESCRIPTION
Changing the test targets to .net5 means that the IDE throws errors where pattern matching can be used. Because we need to also test against older frameworks we can't switch to pattern matching yet. This PR makes the pattern matching a suggestion instead of an error.