### PR TITLE
Prevents stale bot activity on useful PR's

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,6 +4,7 @@ daysUntilStale: 30
 daysUntilClose: 7
 exemptLabels:
   - dependencies
+exemptMilestones: true
 staleLabel: stale
 markComment: >
   This pull request has been automatically marked as stale because it has not had


### PR DESCRIPTION
Some PR's that should be worked on in the future but simply work on it might not happen soon will get closed by stalebot. It is very annoying but this change would prevent that if the PR is assigned to a milestone like "vnext" or similar.