### PR TITLE
Dependabot config updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,4 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
   ignore:
     # Particular.Analyzers updates are distributed via RepoStandards
     - dependency-name: "Particular.Analyzers"
+    # Changing this dependency affects the .NET SDK and Visual Studio version supported by 
+    # a Roslyn analyzer, updates should be more intentional than an automated update
+    - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     # Changing this dependency affects the .NET SDK and Visual Studio version supported by 
     # a Roslyn analyzer, updates should be more intentional than an automated update
     - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
+    # GitVersion updates need to be manually tested and verified before updating to a newer version
+    - dependency-name: "GitVersion.MsBuild"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "04:00"
   open-pull-requests-limit: 10
   ignore:
     # Particular.Analyzers updates are distributed via RepoStandards


### PR DESCRIPTION
* Marks **Microsoft.CodeAnalysis.CSharp.Workspaces** NuGet package as ignored by Dependabot. Incrementing this package version drops support for older versions of the .NET SDK and Visual Studio. We don't want any automation for that.
* Adds GitHub Actions as a package ecosystem, so that actions versions can be kept up-to-date.