### PR TITLE
enable CA1710 and CA1711

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -295,6 +295,8 @@ dotnet_separate_import_directive_groups = false
 #### Naming styles ####
 
 dotnet_diagnostic.IDE1006.severity = error
+dotnet_diagnostic.CA1710.severity = error
+dotnet_diagnostic.CA1711.severity = error
 
 # Naming rules
 dotnet_naming_rule.interface_should_be_begins_with_i.severity = error

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -21,6 +21,8 @@ insert_final_newline = false
 #### Code quality analysis
 
 dotnet_diagnostic.CA1068.severity = error
+dotnet_diagnostic.CA1710.severity = error
+dotnet_diagnostic.CA1711.severity = error
 dotnet_diagnostic.CA2007.severity = error
 dotnet_diagnostic.CA2016.severity = error
 
@@ -295,8 +297,6 @@ dotnet_separate_import_directive_groups = false
 #### Naming styles ####
 
 dotnet_diagnostic.IDE1006.severity = error
-dotnet_diagnostic.CA1710.severity = error
-dotnet_diagnostic.CA1711.severity = error
 
 # Naming rules
 dotnet_naming_rule.interface_should_be_begins_with_i.severity = error


### PR DESCRIPTION
- [CA1710: Identifiers should have correct suffix](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1710)
- [CA1711: Identifiers should not have incorrect suffix](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1711)