### PR TITLE
Updates to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,16 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  labels:
+    - "dependencies"
   open-pull-requests-limit: 10
   ignore:
     # Particular.Analyzers updates are distributed via RepoStandards
     - dependency-name: "Particular.Analyzers"
-    # Changing this dependency affects the .NET SDK and Visual Studio version supported by 
-    # a Roslyn analyzer, updates should be more intentional than an automated update
+    # Changing these 3 dependencies affects the .NET SDK and Visual Studio versions we support 
+    # These types of updates should be more intentional than an automated update
+    - dependency-name: "Microsoft.Build.Utilities.Core"
+    - dependency-name: "Microsoft.CodeAnalysis.CSharp"
     - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
     # GitVersion updates need to be manually tested and verified before updating to a newer version
     - dependency-name: "GitVersion.MsBuild"
@@ -17,4 +21,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  labels:
+    - "dependencies"
+    - "github_actions"
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     interval: daily
   labels:
     - "dependencies"
+    - "NuGet"
   open-pull-requests-limit: 10
   ignore:
     # Particular.Analyzers updates are distributed via RepoStandards


### PR DESCRIPTION
* Standardizes what's going on with the labels, allows us to filter on:
  * All Dependabot with [label:dependencies](https://github.com/pulls?q=is%3Aopen+is%3Apublic+is%3Apr+org%3AParticular+archived%3Afalse+label%3Adependencies
  * All GH Actions updates with [label:dependencies label:github_actions](https://github.com/pulls?q=is%3Aopen+is%3Apublic+is%3Apr+org%3AParticular+archived%3Afalse+label%3Adependencies+label%3Agithub_actions)
  * Only NuGet updates with [label:dependencies label:NuGet](https://github.com/pulls?q=is%3Aopen+is%3Apublic+is%3Apr+org%3AParticular+archived%3Afalse+label%3Adependencies+label%3ANuGet+)
* Should fix the weirdness going on in the [ServicePulse PRs](https://github.com/Particular/ServicePulse/pulls) with the label `Has external dependency which is coming from who knows where
* Marks 2 more NuGet packages as do-not-update because they affect the Visual Studio / .NET SDK versions we support