### PR TITLE
Add .DotSettings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ _NCrunch_*
 # ReSharper is a .NET coding add-in
 _ReSharper*/
 *.[Rr]e[Ss]harper
+*.DotSettings
 *.DotSettings.user
 
 src/scaffolding.config


### PR DESCRIPTION
Since all code style/format related rules should be configured in the editorconfig file now. R# can recreate the .DotSettings file which will then be considered a new file and might be checked accidentally.