### PR TITLE
Clarifying ambiguity of the term "NServiceBus" in our repositories' License file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,10 +1,10 @@
-By accessing NServiceBus code here, you are agreeing to the following licensing terms.
-If you do not agree to these terms, do not access the NServiceBus code.
+By accessing code under the [Particular Software GitHub Organization](https://github.com/Particular) (Particular Software) here, you are agreeing to the following licensing terms.
+If you do not agree to these terms, do not access Particular Software code.
 
-Your license to the NServiceBus source and/or binaries is governed by the Reciprocal Public License 1.5 (RPL1.5) license as described here: 
+Your license to Particular Software source code and/or binaries is governed by the Reciprocal Public License 1.5 (RPL1.5) license as described here: 
 
 https://www.opensource.org/licenses/rpl1.5.txt
 
-If you do not wish to release the source of software you build using NServiceBus, you may use NServiceBus source and/or binaries under the License Agreement described here:
+If you do not wish to release the source of software you build using Particular Software source code and/or binaries, you may use Particular Software source code and/or binaries under the License Agreement described here:
 
 https://particular.net/LicenseAgreement


### PR DESCRIPTION
In order to address https://github.com/Particular/CustomerSuccess/issues/1930

The language proposed here would cover all code in all the repositories in our GitHub organization, including those which do not use the name NServiceBus in them, like ServiceInsight or ServicePulse.