### PR TITLE
Changes for central package management

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -4,4 +4,12 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="particular myget.org" value="https://www.myget.org/F/particular/api/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+        <package pattern="*" />
+    </packageSource>
+    <packageSource key="particular myget.org">
+        <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,11 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
+    <GlobalPackageReference Include="Particular.Analyzers" Version="$(ParticularAnalyzersVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
     <PackageReference Include="Particular.Analyzers" Version="$(ParticularAnalyzersVersion)" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
These changes are required to use NuGet central package management, which has been enabled in ServiceConrol so far.