### PR TITLE
Add links to additional resources to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Community Support
+    url: https://github.com/orgs/community/discussions
+    about: Please ask and answer questions here.
+  - name: GitHub Security Bug Bounty
+    url: https://bounty.github.com/
+    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Ask a question
     url: https://discuss.particular.net/
-    about: Reach out to the particular discourse community.
+    about: Reach out to the ParticularDiscussion community.
   - name: Get support
     url: https://particular.net/support
     about: Please contact us to discuss your support needs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,16 @@
 blank_issues_enabled: false
 contact_links:
-  - name: GitHub Community Support
-    url: https://github.com/orgs/community/discussions
-    about: Please ask and answer questions here.
-  - name: GitHub Security Bug Bounty
-    url: https://bounty.github.com/
-    about: Please report security vulnerabilities here.
+ 
+  - name: Particular support
+    url: https://particular.net/support
+    about: Please contact us to discuss your support needs.
+  - name: Particular Community Support
+    url: https://discuss.particular.net/
+    about: Reach out to the particular discourse community.
+  - name: Particular consulting
+    url: https://particular.net/consulting
+    about: Looking for a quick assessment of your major architectural choices before starting a large development effort.
+  - name: Particular onsite tranining
+    url: https://particular.net/onsite-training
+    about: Please contact us for any onsite training.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,16 +1,11 @@
 blank_issues_enabled: false
 contact_links:
  
-  - name: Particular support
-    url: https://particular.net/support
-    about: Please contact us to discuss your support needs.
-  - name: Particular Community Support
+  - name:  Ask a question
     url: https://discuss.particular.net/
     about: Reach out to the particular discourse community.
-  - name: Particular consulting
-    url: https://particular.net/consulting
-    about: Looking for a quick assessment of your major architectural choices before starting a large development effort.
-  - name: Particular onsite tranining
-    url: https://particular.net/onsite-training
-    about: Please contact us for any onsite training.
+  - name: Get support
+    url: https://particular.net/support
+    about: Please contact us to discuss your support needs.
+
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Reach out to the ParticularDiscussion community.
   - name: Get support
     url: https://particular.net/support
-    about: Please contact us to discuss your support needs.
+    about: Contact us to discuss your support requirements.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,8 @@
 blank_issues_enabled: false
 contact_links:
- 
-  - name:  Ask a question
+  - name: Ask a question
     url: https://discuss.particular.net/
     about: Reach out to the particular discourse community.
   - name: Get support
     url: https://particular.net/support
     about: Please contact us to discuss your support needs.
-
-


### PR DESCRIPTION
Added a config.yml file that adds links to ParitcularDiscuss where users can ask a question, and other support options when opening an issue.

![image](https://user-images.githubusercontent.com/1014386/223477440-f03b914f-3dd3-40f7-8043-b31815f4ebc5.png)
