### PR TITLE
Use regular GITHUB_TOKEN and non-secret var for slack channel

### DIFF
--- a/.github/workflows/virus-scan.yml
+++ b/.github/workflows/virus-scan.yml
@@ -12,6 +12,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           tag: ${{ github.event.release.name }}
-          github-access-token: ${{ secrets.RELEASE_ANTIVIRUS_GITHUB_ACCESS_TOKEN_PBOT4 }}
+          github-access-token: ${{ secrets.GITHUB_TOKEN }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
-          slack-channel: ${{ secrets.VIRUS_REPORTING_SLACK_CHANNEL }}
+          slack-channel: ${{ vars.VIRUS_REPORTING_SLACK_CHANNEL }}


### PR DESCRIPTION
https://github.com/Particular/virus-scan-action/pull/15 proves that it is safe to use the regular `secrets.GITHUB_TOKEN` and isn't necessary to have a Particularbot token.

While we're at it, now that the [vars context](https://docs.github.com/en/actions/learn-github-actions/contexts#vars-context) is available, it would be better to use an org-wide variable (already created) to target Slack reporting rather than an unnecessarily hidden secret.