### PR TITLE
Align on H4s

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,13 +12,13 @@ body:
       label: Describe the bug 
       description: A clear and concise description of the bug.
       value: | 
-        ## Description
+        #### Description
         
-        ## Expected behavior
+        #### Expected behavior
         
-        ## Actual behavior
+        #### Actual behavior
         
-        ## Versions
+        #### Versions
         
         Please list the version of the relevant packages or applications in which the bug exists.        
     validations:
@@ -42,10 +42,10 @@ body:
       label: Additional Information
       description: If there are any possible solutions, workarounds, or additional information please describe them here
       value: | 
-       ## Workarounds
+       #### Workarounds
        
-       ## Possible solutions
+       #### Possible solutions
        
-       ## Additional information
+       #### Additional information
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -16,12 +16,11 @@ body:
       description: A clear and concise description of the feature.
 
       value: | 
-        **Is your feature related to a problem? Please describe.**
+        #### Is your feature related to a problem? Please describe.
         
-        **Describe the requested feature**
-
+        #### Describe the requested feature
                 
-        **Describe alternatives you've considered**
+        #### Describe alternatives you've considered
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/improvement_request.yml
+++ b/.github/ISSUE_TEMPLATE/improvement_request.yml
@@ -12,11 +12,11 @@ body:
       label: Describe the suggested improvement
       description: A clear and concise description of what the improvement is.    
       value: | 
-        **Is your improvement related to a problem? Please describe.**
+        #### Is your improvement related to a problem? Please describe.
         
-        **Describe the suggested solution**
+        #### Describe the suggested solution
                 
-        **Describe alternatives you've considered**
+        #### Describe alternatives you've considered
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
In the new issue templates, GitHub expresses each section as an H3, so having an H2 in the template makes for a weird inverse header relationship. This fixes it by making all the headings underneath a textarea section an H4.

Only the bug report was using headings, the others were using bold text. But H4s render the same as bold text on GitHub, so we might as well align on headings, which are probably more semantically useful.