### PR TITLE
Let AnalysisLevel be customized

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>5.0</AnalysisLevel>
+    <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">5.0</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <!-- To lock the version of Particular.Analyzers, for example, in a release branch, set this property in Custom.Build.props -->
     <ParticularAnalyzersVersion Condition="'$(ParticularAnalyzersVersion)' == ''">1.8.0</ParticularAnalyzersVersion>


### PR DESCRIPTION
This change maintains the default `AnalysisLevel` of 5.0, but lets us customize it in Custom.Build.props.

This ensures that existing branches won't get new analyzer errors just by merging this change, but on a per-repo and per-branch basis, we can start increasing the level to enable the new analyzers that have shipped in SDKs past .NET 5.
