### PR TITLE
Make IDE0028 a suggestion

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -65,8 +65,8 @@ dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:err
 dotnet_diagnostic.IDE0017.severity = error
 dotnet_style_object_initializer = true:error
 
-dotnet_diagnostic.IDE0028.severity = error
-dotnet_style_collection_initializer = true:error
+dotnet_diagnostic.IDE0028.severity = suggestion
+dotnet_style_collection_initializer = true:suggestion
 
 dotnet_diagnostic.IDE0033.severity = error
 dotnet_style_explicit_tuple_names = true:error


### PR DESCRIPTION
This analyzer has started flagging things that can be changed based on new C# 12 language features, but the matching VS fixer hasn't shipped yet.

This PR turns this into a suggestion for now to unblock repos. Once we have the fixer, we can look into changing the code and then turning this back into an error.