### PR TITLE
Add local packages feed to package source mappings

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -6,10 +6,13 @@
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
-        <package pattern="*" />
+      <package pattern="*" />
     </packageSource>
     <packageSource key="particular packages">
-        <package pattern="*" />
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="local packages">
+      <package pattern="*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
This adds a `local packages` package source mapping so that you can have a local folder set up as package source. The only requirement is that the source needs to be named 'local packages` (case sensitive):

![image](https://github.com/Particular/RepoStandards/assets/753669/456c8380-a03c-470e-b29c-e06d9abd2a3f)
