### PR TITLE
Add props and targets to "project file" formatting

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,7 +1,7 @@
 # TODO: Uncomment when analyzer line ending problem is fixed
 #root = true
 
-[*.{csproj,xml}]
+[*.{csproj,props,targets,xml}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
This ensures that `.props` and `.targets` files get the same formatting rules that we want for other XML "project files".