### PR TITLE
Make IDE0100 a suggestion for now

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -241,7 +241,8 @@ dotnet_diagnostic.IDE0079.severity = error
 dotnet_remove_unnecessary_suppression_exclusions = none
 
 dotnet_diagnostic.IDE0080.severity = error
-dotnet_diagnostic.IDE0100.severity = error
+# Change IDE0100 to suggestion until 8.0.300 SDK works in VS and we can decide how to fix the errors
+dotnet_diagnostic.IDE0100.severity = suggestion
 dotnet_diagnostic.IDE0110.severity = error
 
 


### PR DESCRIPTION
The 8.0.300 SDK is causing new errors for `IDE0100`, but 8.0.300 doesn't work properly with Visual Studio 17.9.7. With it installed, the SDK analyzers don't work. For example:
```
The analyzer assembly 'C:\Program Files\dotnet\sdk\8.0.300\Sdks\Microsoft.NET.Sdk\codestyle\cs\Microsoft.CodeAnalysis.CodeStyle.dll' references version '4.10.0.0' of the compiler, which is newer than the currently running version '4.9.0.0'.	ServiceControl.Audit.Persistence.SagaAudit	C:\Program Files\dotnet\sdk\8.0.300\Sdks\Microsoft.NET.Sdk\codestyle\cs\Microsoft.CodeAnalysis.CodeStyle.dll
```

Until we can run the analzyers inside of Visual Studio, there's no easy way to fix up the code that is triggering `IDE0100`.

This PR turns `IDE0100` into a suggestion as a workaround for now.
