### PR TITLE
NuGet updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
+registries:
+  particular-packages:
+    type: nuget-feed
+    url: https://f.feedz.io/particular-software/packages/nuget/index.json
 updates:
 - package-ecosystem: nuget
   directory: "/src"
+  registries: "*"
   schedule:
     interval: daily
   open-pull-requests-limit: 1000

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The files managed by the synchronization tool cannot be customized in individual
 The following files have an extension point that allow for customization:
 
 * `Directory.Build.props`: Include any custom settings in a `Custom.Build.props` file located next to the `Directory.Build.props` file.
-`.gitignore`: Use [nested ignore files](https://git-scm.com/docs/gitignore#_description) to ignore custom files and folders.
+* `.gitignore`: Use [nested ignore files](https://git-scm.com/docs/gitignore#_description) to ignore custom files and folders.
 
 ## Centralized configuration
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,8 +7,8 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel Condition="'$(AnalysisLevel)' == ''">5.0</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <!-- NuGetAuditMode set to 'all' for tool projects in Directory.Build.targets, other project types default to 'direct' -->
     <NuGetAuditLevel>low</NuGetAuditLevel>
+    <NuGetAuditMode Condition="'$(NuGetAuditMode)' == ''">all</NuGetAuditMode>
     <!-- To lock the version of Particular.Analyzers, for example, in a release branch, set this property in Custom.Build.props -->
     <ParticularAnalyzersVersion Condition="'$(ParticularAnalyzersVersion)' == ''">2.1.2</ParticularAnalyzersVersion>
     <NServiceBusKey>0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92</NServiceBusKey>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <NuGetAuditLevel>low</NuGetAuditLevel>
     <NuGetAuditMode Condition="'$(NuGetAuditMode)' == ''">all</NuGetAuditMode>
     <!-- To lock the version of Particular.Analyzers, for example, in a release branch, set this property in Custom.Build.props -->
-    <ParticularAnalyzersVersion Condition="'$(ParticularAnalyzersVersion)' == ''">2.1.2</ParticularAnalyzersVersion>
+    <ParticularAnalyzersVersion Condition="'$(ParticularAnalyzersVersion)' == ''">2.1.3</ParticularAnalyzersVersion>
     <NServiceBusKey>0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92</NServiceBusKey>
     <NServiceBusTestsKey>00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5</NServiceBusTestsKey>
   </PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,9 +1,5 @@
 <Project>
 
-  <PropertyGroup>
-    <NuGetAuditMode Condition="'$(PackAsTool)' == 'true'">all</NuGetAuditMode>
-  </PropertyGroup>
-
   <Import Project="msbuild\AutomaticVersionRanges.targets" Condition="Exists('msbuild\AutomaticVersionRanges.targets')" />
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,4 +4,6 @@
     <NuGetAuditMode Condition="'$(PackAsTool)' == 'true'">all</NuGetAuditMode>
   </PropertyGroup>
 
+  <Import Project="msbuild\AutomaticVersionRanges.targets" Condition="Exists('msbuild\AutomaticVersionRanges.targets')" />
+
 </Project>

--- a/src/msbuild/AutomaticVersionRanges.targets
+++ b/src/msbuild/AutomaticVersionRanges.targets
@@ -1,0 +1,42 @@
+<Project>
+
+  <PropertyGroup>
+    <AutomaticVersionRangesEnabled Condition="'$(AutomaticVersionRangesEnabled)' == '' And '$(Configuration)' == 'Debug'">false</AutomaticVersionRangesEnabled>
+    <AutomaticVersionRangesEnabled Condition="'$(AutomaticVersionRangesEnabled)' == '' And '$(IsPackable)' == 'false'">false</AutomaticVersionRangesEnabled>
+    <AutomaticVersionRangesEnabled Condition="'$(AutomaticVersionRangesEnabled)' == '' And '$(ManagePackageVersionsCentrally)' == 'true'">false</AutomaticVersionRangesEnabled>
+    <AutomaticVersionRangesEnabled Condition="'$(AutomaticVersionRangesEnabled)' == ''">true</AutomaticVersionRangesEnabled>
+  </PropertyGroup>
+
+  <UsingTask TaskName="ConvertToVersionRange" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <Task>
+      <Code Source="$(MSBuildThisFileDirectory)ConvertToVersionRange.cs" />
+    </Task>
+  </UsingTask>
+
+  <Target Name="ConvertProjectReferenceVersionsToVersionRanges" AfterTargets="_GetProjectReferenceVersions" Condition="'$(AutomaticVersionRangesEnabled)' == 'true'">
+    <PropertyGroup>
+      <NumberOfProjectReferences>@(_ProjectReferencesWithVersions->Count())</NumberOfProjectReferences>
+    </PropertyGroup>
+    <ConvertToVersionRange Condition="$(NumberOfProjectReferences) &gt; 0" References="@(_ProjectReferencesWithVersions)" VersionProperty="ProjectVersion">
+      <Output TaskParameter="ReferencesWithVersionRanges" ItemName="_ProjectReferencesWithVersionRanges" />
+    </ConvertToVersionRange>
+    <ItemGroup Condition="$(NumberOfProjectReferences) &gt; 0">
+      <_ProjectReferencesWithVersions Remove="@(_ProjectReferencesWithVersions)" />
+      <_ProjectReferencesWithVersions Include="@(_ProjectReferencesWithVersionRanges)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ConvertPackageReferenceVersionsToVersionRanges" BeforeTargets="CollectPackageReferences" Condition="'$(AutomaticVersionRangesEnabled)' == 'true'">
+    <PropertyGroup>
+      <NumberOfPackageReferences>@(PackageReference->Count())</NumberOfPackageReferences>
+    </PropertyGroup>
+    <ConvertToVersionRange Condition="$(NumberOfPackageReferences) &gt; 0" References="@(PackageReference)" VersionProperty="Version">
+      <Output TaskParameter="ReferencesWithVersionRanges" ItemName="_PackageReferencesWithVersionRanges" />
+    </ConvertToVersionRange>
+    <ItemGroup Condition="$(NumberOfPackageReferences) &gt; 0">
+      <PackageReference Remove="@(PackageReference)" />
+      <PackageReference Include="@(_PackageReferencesWithVersionRanges)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/msbuild/ConvertToVersionRange.cs
+++ b/src/msbuild/ConvertToVersionRange.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class ConvertToVersionRange : Task
+{
+    [Required]
+    public ITaskItem[] References { get; set; } = [];
+
+    [Required]
+    public string VersionProperty { get; set; } = string.Empty;
+
+    [Output]
+    public ITaskItem[] ReferencesWithVersionRanges { get; private set; } = [];
+
+    public override bool Execute()
+    {
+        var success = true;
+
+        foreach (var reference in References)
+        {
+            var automaticVersionRange = reference.GetMetadata("AutomaticVersionRange");
+
+            if (automaticVersionRange.Equals("false", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var privateAssets = reference.GetMetadata("PrivateAssets");
+
+            if (privateAssets.Equals("All", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var version = reference.GetMetadata(VersionProperty);
+            var match = Regex.Match(version, @"^\d+");
+
+            if (match.Value.Equals(string.Empty, StringComparison.Ordinal))
+            {
+                Log.LogError("Reference '{0}' with version '{1}' is not valid for automatic version range conversion. Fix the version or exclude the reference from conversion by setting 'AutomaticVersionRange=\"false\"' on the reference.", reference.ItemSpec, version);
+                success = false;
+                continue;
+            }
+
+            var nextMajor = Convert.ToInt32(match.Value) + 1;
+
+            var versionRange = $"[{version}, {nextMajor}.0.0)";
+            reference.SetMetadata(VersionProperty, versionRange);
+        }
+
+        ReferencesWithVersionRanges = References;
+
+        return success;
+    }
+}


### PR DESCRIPTION
This PR makes changes to prepare for handling vulnerabilities reported by NuGet's security audit feature.

- We're now explicitly setting `NuGetAuditMode` in `Directory.Build.props` to `all` to match the default value coming in the 9.0.100 SDK. This value can be set in `Custom.Build.props` to override the value globally, something we might end up needing to do on older release branches, for example.
- To make it easier to update `PackageReference` versions and to eliminate the need for duplicate references in test projects, the automatic version ranges feature added here will automatically create the version ranges for any packages that are created.
- Dependabot stopped considering the Feedz feed for its package updating portion of its process, so packages that are only on Feedz weren't being updated. This seems like a bug, but adding it to the `dependebot.yml` makes it work again, so for now we'll stick with that.