### PR TITLE
Distribute code analysis workflow

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,0 +1,12 @@
+name: Code Analysis
+on:
+  push:
+    branches:
+      - main
+      - master
+      - release-*
+  pull_request:
+  workflow_dispatch:
+jobs:
+  code-analysis:
+    uses: particular/shared-workflows/.github/workflows/code-analysis.yml@main

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -5,7 +5,6 @@ on:
       - main
       - master
       - release-*
-  pull_request:
   workflow_dispatch:
 jobs:
   code-analysis:


### PR DESCRIPTION
Adds code analysis to the push triggers on default/release branches, as well as workflow_dispatch. The latter allows it to be invoked centrally on all release branches in order to get feedback on what works where. After the code analysis action is fixed up to work everywhere and everything is green, a `pull_request` trigger can be added.