### PR TITLE
Automatically nest files via project capability

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,4 +31,8 @@
     <SourceRoot Include="$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)..\))" />
   </ItemGroup>
 
+  <ItemGroup>
+   <ProjectCapability Include="DynamicFileNestingEnabled" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This setting will enable file nesting in Solution Explorer based on the names of the files.