### PR TITLE
Support automatic version range segments based on 2 or 3 segments

### DIFF
--- a/src/msbuild/ConvertToVersionRange.cs
+++ b/src/msbuild/ConvertToVersionRange.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -35,18 +35,38 @@ public class ConvertToVersionRange : Task
             }
 
             var version = reference.GetMetadata(VersionProperty);
-            var match = Regex.Match(version, @"^\d+");
+            // Strip any prerelease suffix (e.g. "1.0.0-alpha.2") before extracting segments.
+            var versionCore = Regex.Match(version, @"^[\d.]+").Value;
+            var segments = Regex.Matches(versionCore, @"\d+");
 
-            if (match.Value.Equals(string.Empty, StringComparison.Ordinal))
+            if (segments.Count == 0)
             {
                 Log.LogError("Reference '{0}' with version '{1}' is not valid for automatic version range conversion. Fix the version or exclude the reference from conversion by setting 'AutomaticVersionRange=\"false\"' on the reference.", reference.ItemSpec, version);
                 success = false;
                 continue;
             }
 
-            var nextMajor = Convert.ToInt32(match.Value) + 1;
+            // AutomaticVersionRangeSegments controls which segment is bumped to form the upper bound.
+            // Default 1 (SemVer: bump major). For vendors that don't follow SemVer and introduce
+            // breaking changes in 2nd, or 3rd segment of versions numbers (e.g. IBM MQ, RavenDB)
+            var segmentsMetadata = reference.GetMetadata("AutomaticVersionRangeSegments");
+            var segmentCount = 1;
+            if (!string.IsNullOrEmpty(segmentsMetadata) && (!int.TryParse(segmentsMetadata, out segmentCount) || segmentCount < 1))
+            {
+                Log.LogError("Reference '{0}' has invalid AutomaticVersionRangeSegments value '{1}'. Must be a positive integer.", reference.ItemSpec, segmentsMetadata);
+                success = false;
+                continue;
+            }
 
-            var versionRange = $"[{version}, {nextMajor}.0.0)";
+            var effectiveCount = Math.Min(segmentCount, segments.Count);
+            var parts = new string[effectiveCount];
+            for (var i = 0; i < effectiveCount; i++)
+            {
+                parts[i] = segments[i].Value;
+            }
+            parts[effectiveCount - 1] = (Convert.ToInt32(parts[effectiveCount - 1]) + 1).ToString();
+
+            var versionRange = $"[{version}, {string.Join(".", parts)})";
             reference.SetMetadata(VersionProperty, versionRange);
         }
 


### PR DESCRIPTION
Support automatic version range segments based on 2 or 3 segments. Useful when packages not follow SemVer and introduce breaking changes in non major version releases.

This PR introduced a new XML attribute `AutomaticVersionRangeSegments`.

If not specified it uses value `1`, but can be explicitly set. 

```txt
1 =>  1.1.2 => [1.1.2, 2.0.0)
2 =>  1.1.2 => [1.1.2, 1.2.0)
3 =>  1.1.2 => [1.1.2, 1.1.3) (e.g allow 1.1.2, 1.1.2.1, 1.1.2.2, etc.)
```

An alternative solution would be to re-use `AutomaticVersionRange` which currently supports `True` and `False` and add more values like `Major`, `Minor`, `Patch`.
